### PR TITLE
add CLI description to the Options

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,28 +14,34 @@ MEAL_LIST = "data/meal_list.csv"
 #absolute_path = os.path.join(os.path.dirname(__file__), f"../data/{MEAL_LIST}")
 absolute_path = Path(__file__).parent / MEAL_LIST
 
-def main(data: str = MEAL_LIST, rank: bool = False, TA: bool = None, inp: bool = False, kosher: str = "fleisch"):
-    """
-    data ::: str, csv file with the meal data - default meal_list.csv in the data folder.
 
-    rank ::: uses weights from the rank feature for random meal.
+def main(
+    data: str = typer.Option(MEAL_LIST, help="csv file with the meal data"),
+    rank: bool = typer.Option(
+        False, help="uses weights from the rank feature for random meal"),
+    TA: bool = typer.Option(
+        None, "--ta/--no-ta",
+        help='''True: chooses only from takeaway,
 
-    TA   ::: True-chooses only from takeaway, False-choose from everythin except TA, no-flag - choose from everything including TA.
+False: from everythin except TA,
 
-    inp  ::: Add a new meal to the meal DB, by questions to the audience. 
-    """
+no-flag: choose from everything including TA'''),
+    inp: bool = typer.Option(
+        False, help="Add a new meal to the meal DB, by questions to the audience"),
+    kosher: aux.Kosher = typer.Option(aux.Kosher.fleisch, case_sensitive=False)
+):
     #typer.echo(f"Choosing meal from {kosher.value}")
-    
+
     meals_db = pd.read_csv(absolute_path, index_col=0)
-    
+
     meals_db = aux.filter_kosher(meals_db, kosher)
     if inp:
         new_meal = iod.meal_questions(meals_db)
-        meals_db = iod.add_meal(meals_db, new_meal) 
+        meals_db = iod.add_meal(meals_db, new_meal)
     else:
         meals_db, chosen_one = aux.choose_random(meals_db, rank, TA)
         iod.write_to_log(chosen_one)
-     
+
     # save changes
     iod.save_data(meals_db, absolute_path)
 

--- a/scripts/auxillary.py
+++ b/scripts/auxillary.py
@@ -2,6 +2,7 @@
 main random meal choice function and its tiny helpers
 this is called auxiallary as it is supposed to support the main main.py file
 '''
+from enum import Enum
 import pandas as pd
 import os
 from pathlib import Path
@@ -9,6 +10,11 @@ try:
     import scripts.iodata as iod
 except:
     import iodata as iod
+
+class Kosher(str, Enum):
+    parve= "parve"
+    fleisch = "fleisch"
+    milchik = "milchik"
 
 def choose_random(meals, rank: bool = False, times: bool = False, last_made: bool = False, TA=None, k=1):
     '''
@@ -107,7 +113,7 @@ def reboot_time_timestamps(data="meal_list.csv",logfile="meal.log"):
             print("Data was reset and saved")
             return 0
 
-def filter_kosher(meal_list, kosher):
+def filter_kosher(meal_list, kosher: Kosher):
     '''
     Takes loaded meal_list DF and returns the filtered meals according to specified kosher
 


### PR DESCRIPTION
```
❯ python3 main.py --help
Usage: main.py [OPTIONS]

Options:
  --data TEXT                     csv file with the meal data  [default:
                                  data/meal_list.csv]

  --rank / --no-rank              uses weights from the rank feature for
                                  random meal  [default: False]

  --ta / --no-ta                  True: chooses only from takeaway,
                                  
                                  False: from everythin except TA,
                                  
                                  no-flag: choose from everything including TA

  --inp / --no-inp                Add a new meal to the meal DB, by questions
                                  to the audience  [default: False]

  --kosher [parve|fleisch|milchik]
                                  [default: fleisch]
  --install-completion            Install completion for the current shell.
  --show-completion               Show completion for the current shell, to
                                  copy it or customize the installation.

  --help                          Show this message and exit.
```
